### PR TITLE
Fix NPE when using Accept filenames from previous transform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ Workflow Run Configuration/
 Hop Server/
 Relational Database Connection/
 \.temp-beam-*/
-
+.claude/
+.serena/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ Install by extracting into `plugins/tech/parquet-enhanced/` inside a Hop install
 - **No co-author references** in commit messages or PR descriptions
 - **Every code change on a dedicated branch**, then merged into `main` via PR
 - **Every work plan item must be mapped to a GitHub Issue**
+- **Claude creates PRs, the user merges them** — never merge a PR autonomously
 
 ## Work Plans
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,12 @@ Install by extracting into `plugins/tech/parquet-enhanced/` inside a Hop install
 ## Git and PR Rules
 
 - **No co-author references** in commit messages or PR descriptions
+- **Every code change on a dedicated branch**, then merged into `main` via PR
+- **Every work plan item must be mapped to a GitHub Issue**
+
+## Work Plans
+
+- Work plans are saved in `docs/PIANO_LAVORO.md` for reference
 
 ## Diagrams and Mockups
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,111 @@
+# CLAUDE.md — hop-parquet-plugin-enhanced
+
+## Project Overview
+
+Apache Hop plugin that provides enhanced Parquet file input/output transforms, replacing the standard Parquet plugin bundled with Hop.
+
+- **Two transforms**: `ParquetInputEnhanced` (read) and `ParquetOutputEnhanced` (write)
+- **Target platform**: Apache Hop 2.16.2+
+- **License**: Apache 2.0 (ASF header required on all Java files)
+
+## Tech Stack
+
+| Component       | Version  |
+|-----------------|----------|
+| Java (source)   | 11       |
+| Java (CI)       | 17       |
+| Apache Hop      | 2.16.2   |
+| Apache Parquet  | 1.15.2   |
+| Hadoop Client   | 3.3.6    |
+| Lombok          | 1.18.34  |
+| Build           | Maven    |
+
+## Module Structure
+
+```
+pom.xml                          # Parent POM (packaging: pom)
+transforms/
+  parquet-enhanced/              # Main code module (parent: hop:2.16.2)
+    src/main/java/org/apache/hop/parquet/transforms/
+      input/                     # ParquetInputEnhanced (13 classes)
+      output/                    # ParquetOutputEnhanced (11 classes)
+    src/main/resources/          # i18n messages, SVG icons
+assemblies/
+  assemblies-parquet-enhanced/   # Assembly for distribution zip
+```
+
+## Build Commands
+
+**Always use `-s .m2/settings.xml`** — custom Maven settings referencing GitHub Packages for Hop artifacts.
+
+```bash
+# Full build
+mvn clean package -s .m2/settings.xml
+
+# Verify (CI uses this)
+mvn clean verify -s .m2/settings.xml
+
+# Compile only
+mvn clean compile -s .m2/settings.xml
+```
+
+Requires `GITHUB_ACTOR` and `GITHUB_TOKEN` environment variables for GitHub Packages authentication.
+
+## Code Conventions
+
+### Apache Hop Transform Pattern
+Every transform consists of 3-4 classes:
+- `*Meta` — metadata/configuration, annotated with `@Transform`, extends `BaseTransformMeta<T, D>`
+- `*Data` — runtime data holder, extends `BaseTransformData`
+- Main class (no suffix) — execution logic, extends `BaseTransform<Meta, Data>`
+- `*Dialog` — SWT UI dialog for Hop GUI
+
+### Lifecycle: `init()` -> `processRow()` -> `dispose()`
+
+### Annotations
+- `@Transform(id, image, name, description, ...)` — transform registration
+- `@HopMetadataProperty(key, groupKey, injectionKeyDescription)` — field serialization
+- `@Getter` / `@Setter` (Lombok) — used on all Meta fields
+- Jandex plugin indexes annotations at build time
+
+### i18n
+- Pattern: `BaseMessages.getString(PKG, "key")`
+- Messages in `messages_en_US.properties` and `messages_it_IT.properties`
+- All user-facing strings must be in both locales
+
+### File Access
+Uses Apache Commons VFS (`HopVfs`) for filesystem abstraction. Files read entirely into memory before Parquet parsing.
+
+## CI/CD
+
+- **PR builds** (`.github/workflows/pr-build.yml`): `mvn clean verify` on ubuntu-latest, JDK 17
+- **Releases** (`.github/workflows/release.yml`): triggered by `v*` tags from `main`, creates GitHub Release with assembly zip
+
+## Distribution
+
+The assembly produces `assemblies/assemblies-parquet-enhanced/target/hop-parquet-plugin-*.zip`.
+Install by extracting into `plugins/tech/parquet-enhanced/` inside a Hop installation.
+
+## Language Rules
+
+- **Code documentation, commit messages, PR descriptions**: always in English
+- **GitHub Issues**: managed in Italian
+- **Working sessions**: interact with the user in Italian
+
+## Git and PR Rules
+
+- **No co-author references** in commit messages or PR descriptions
+
+## Diagrams and Mockups
+
+- **Diagrams** in generated documents: always use **Mermaid** syntax
+- **GUI mockups**: always produce **Draw.io** (`.drawio`) files
+
+## Task Completion Checklist
+
+1. Build passes: `mvn clean verify -s .m2/settings.xml`
+2. ASF 2.0 license header on all new Java files
+3. New strings added to both `messages_en_US.properties` and `messages_it_IT.properties`
+4. Lombok `@Getter`/`@Setter` on Meta fields, `@HopMetadataProperty` for serialization
+5. New runtime dependencies added to `assembly.xml`
+6. No unit tests exist yet — consider adding them for new logic

--- a/Claude.md
+++ b/Claude.md
@@ -1,4 +1,0 @@
-
-# Core rules
-
-* Build project with maven option -s .m2/settings.xml

--- a/transforms/parquet-enhanced/src/main/java/org/apache/hop/parquet/transforms/input/ParquetInputEnhancedMeta.java
+++ b/transforms/parquet-enhanced/src/main/java/org/apache/hop/parquet/transforms/input/ParquetInputEnhancedMeta.java
@@ -387,7 +387,7 @@ public class ParquetInputEnhancedMeta
   public FileInputList getFileList(IVariables variables) {
 
     if (fileItems == null || fileItems.isEmpty()) {
-      return null;
+      return new FileInputList();
     }
 
     String[] fileName = new String[fileItems.size()];


### PR DESCRIPTION
## Summary
- Fix NullPointerException in `ParquetInputEnhancedMeta.getFileInputList()` when using "Accept filenames from previous transform" option — return empty `FileInputList` instead of `null` (line 390)
- Replace old `Claude.md` with proper `CLAUDE.md` containing full project conventions
- Add branch workflow, issue tracking, and work plan rules to CLAUDE.md

Closes #6

## Test plan
- [x] Tested manually: pipeline with "Accept filenames from previous transform" no longer throws NPE
- [ ] Verify build passes with `mvn clean verify -s .m2/settings.xml`