### PR TITLE
Fix ParquetVersion fallback and ParquetOutputStream position tracking (#11)

### DIFF
--- a/transforms/parquet-enhanced/src/main/java/org/apache/hop/parquet/transforms/output/ParquetOutputStream.java
+++ b/transforms/parquet-enhanced/src/main/java/org/apache/hop/parquet/transforms/output/ParquetOutputStream.java
@@ -36,8 +36,8 @@ public class ParquetOutputStream extends PositionOutputStream {
 
   @Override
   public void write(int b) throws IOException {
-    position++;
     outputStream.write(b);
+    position++;
   }
 
   @Override

--- a/transforms/parquet-enhanced/src/main/java/org/apache/hop/parquet/transforms/output/ParquetVersion.java
+++ b/transforms/parquet-enhanced/src/main/java/org/apache/hop/parquet/transforms/output/ParquetVersion.java
@@ -17,6 +17,7 @@
 
 package org.apache.hop.parquet.transforms.output;
 
+import java.util.logging.Logger;
 import org.apache.hop.metadata.api.IEnumHasCode;
 
 public enum ParquetVersion implements IEnumHasCode {
@@ -39,12 +40,19 @@ public enum ParquetVersion implements IEnumHasCode {
     return descriptions;
   }
 
+  private static final Logger logger = Logger.getLogger(ParquetVersion.class.getName());
+
   public static ParquetVersion getVersionFromDescription(String description) {
     for (ParquetVersion version : values()) {
-      if (version.getDescription().equals(description)) {
+      if (version.getDescription().equalsIgnoreCase(description)) {
         return version;
       }
     }
+    logger.warning(
+        "Unknown Parquet version description '"
+            + description
+            + "', falling back to "
+            + Version1.getDescription());
     return Version1;
   }
 

--- a/transforms/parquet-enhanced/src/test/java/org/apache/hop/parquet/transforms/output/ParquetOutputStreamTest.java
+++ b/transforms/parquet-enhanced/src/test/java/org/apache/hop/parquet/transforms/output/ParquetOutputStreamTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.parquet.transforms.output;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import org.junit.jupiter.api.Test;
+
+class ParquetOutputStreamTest {
+
+  @Test
+  void testWriteSingleByteIncrementsPosition() throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ParquetOutputStream pos = new ParquetOutputStream(baos);
+
+    assertEquals(0, pos.getPos());
+    pos.write(42);
+    assertEquals(1, pos.getPos());
+  }
+
+  @Test
+  void testWriteByteArrayIncrementsPositionByLength() throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ParquetOutputStream pos = new ParquetOutputStream(baos);
+
+    byte[] data = new byte[] {1, 2, 3, 4, 5};
+    pos.write(data, 0, data.length);
+    assertEquals(5, pos.getPos());
+  }
+
+  @Test
+  void testWriteByteArrayDelegatesToWriteWithOffsetAndLength() throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ParquetOutputStream pos = new ParquetOutputStream(baos);
+
+    byte[] data = new byte[] {10, 20, 30};
+    pos.write(data);
+    assertEquals(3, pos.getPos());
+    assertArrayEquals(data, baos.toByteArray());
+  }
+
+  @Test
+  void testCumulativePosition() throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ParquetOutputStream pos = new ParquetOutputStream(baos);
+
+    pos.write(1);
+    pos.write(new byte[] {2, 3}, 0, 2);
+    pos.write(4);
+    assertEquals(4, pos.getPos());
+  }
+
+  @Test
+  void testGetPosInitiallyZero() throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ParquetOutputStream pos = new ParquetOutputStream(baos);
+    assertEquals(0, pos.getPos());
+  }
+
+  @Test
+  void testFlushDelegatesToUnderlyingStream() throws IOException {
+    OutputStream mockStream = mock(OutputStream.class);
+    ParquetOutputStream pos = new ParquetOutputStream(mockStream);
+
+    pos.flush();
+    verify(mockStream).flush();
+  }
+
+  @Test
+  void testCloseDelegatesToUnderlyingStream() throws IOException {
+    OutputStream mockStream = mock(OutputStream.class);
+    ParquetOutputStream pos = new ParquetOutputStream(mockStream);
+
+    pos.close();
+    verify(mockStream).close();
+  }
+
+  @Test
+  void testPositionNotIncrementedOnWriteSingleByteFailure() throws IOException {
+    OutputStream mockStream = mock(OutputStream.class);
+    doThrow(new IOException("write failed")).when(mockStream).write(anyInt());
+
+    ParquetOutputStream pos = new ParquetOutputStream(mockStream);
+    assertEquals(0, pos.getPos());
+
+    assertThrows(IOException.class, () -> pos.write(42));
+    assertEquals(0, pos.getPos());
+  }
+
+  @Test
+  void testPositionNotIncrementedOnWriteByteArrayFailure() throws IOException {
+    OutputStream mockStream = mock(OutputStream.class);
+    doThrow(new IOException("write failed"))
+        .when(mockStream)
+        .write(any(byte[].class), anyInt(), anyInt());
+
+    ParquetOutputStream pos = new ParquetOutputStream(mockStream);
+    assertEquals(0, pos.getPos());
+
+    byte[] data = new byte[] {1, 2, 3};
+    assertThrows(IOException.class, () -> pos.write(data, 0, data.length));
+    assertEquals(0, pos.getPos());
+  }
+}

--- a/transforms/parquet-enhanced/src/test/java/org/apache/hop/parquet/transforms/output/ParquetVersionTest.java
+++ b/transforms/parquet-enhanced/src/test/java/org/apache/hop/parquet/transforms/output/ParquetVersionTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.parquet.transforms.output;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ParquetVersionTest {
+
+  @Test
+  void testGetVersionFromDescriptionVersion1() {
+    assertEquals(ParquetVersion.Version1, ParquetVersion.getVersionFromDescription("Parquet 1.0"));
+  }
+
+  @Test
+  void testGetVersionFromDescriptionVersion2() {
+    assertEquals(ParquetVersion.Version2, ParquetVersion.getVersionFromDescription("Parquet 2.0"));
+  }
+
+  @Test
+  void testGetVersionFromDescriptionCaseInsensitive() {
+    assertEquals(ParquetVersion.Version1, ParquetVersion.getVersionFromDescription("parquet 1.0"));
+    assertEquals(ParquetVersion.Version2, ParquetVersion.getVersionFromDescription("parquet 2.0"));
+    assertEquals(ParquetVersion.Version2, ParquetVersion.getVersionFromDescription("PARQUET 2.0"));
+  }
+
+  @Test
+  void testGetVersionFromDescriptionNullFallsBackToVersion1() {
+    // null description cannot match any version, so it falls back to Version1
+    assertEquals(ParquetVersion.Version1, ParquetVersion.getVersionFromDescription(null));
+  }
+
+  @Test
+  void testGetVersionFromDescriptionEmptyStringFallsBackToVersion1() {
+    assertEquals(ParquetVersion.Version1, ParquetVersion.getVersionFromDescription(""));
+  }
+
+  @Test
+  void testGetVersionFromDescriptionInvalidFallsBackToVersion1() {
+    assertEquals(ParquetVersion.Version1, ParquetVersion.getVersionFromDescription("invalid"));
+  }
+
+  @Test
+  void testGetDescriptionsReturnsAllDescriptions() {
+    String[] descriptions = ParquetVersion.getDescriptions();
+    assertEquals(2, descriptions.length);
+    assertEquals("Parquet 1.0", descriptions[0]);
+    assertEquals("Parquet 2.0", descriptions[1]);
+  }
+
+  @Test
+  void testGetCode() {
+    assertEquals("1.0", ParquetVersion.Version1.getCode());
+    assertEquals("2.0", ParquetVersion.Version2.getCode());
+  }
+
+  @Test
+  void testGetDescription() {
+    assertEquals("Parquet 1.0", ParquetVersion.Version1.getDescription());
+    assertEquals("Parquet 2.0", ParquetVersion.Version2.getDescription());
+  }
+}


### PR DESCRIPTION
## Summary

- **ParquetVersion**: `getVersionFromDescription()` now uses case-insensitive matching (`equalsIgnoreCase`) and logs a warning when falling back to the default `Version1` for unrecognized input
- **ParquetOutputStream**: Fixed `write(int)` to increment position **after** the underlying write succeeds, preventing position drift on I/O errors (consistent with the `write(byte[],int,int)` method)
- Added comprehensive unit tests for both classes (18 new tests)

Fixes #11

## Test plan

- [x] All 79 tests pass: `mvn test -s .m2/settings.xml -pl transforms/parquet-enhanced`
- [x] ParquetVersionTest: valid lookups, case-insensitive matching, null/empty/invalid fallback, getDescriptions(), getCode()
- [x] ParquetOutputStreamTest: position tracking for single byte and byte array writes, cumulative position, flush/close delegation, position not incremented on write failure