### PR TITLE
Add unit tests for buildFilename and getFields

### DIFF
--- a/transforms/parquet-enhanced/src/test/java/org/apache/hop/parquet/transforms/input/ParquetInputEnhancedMetaTest.java
+++ b/transforms/parquet-enhanced/src/test/java/org/apache/hop/parquet/transforms/input/ParquetInputEnhancedMetaTest.java
@@ -1,0 +1,354 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.parquet.transforms.input;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.hop.core.HopEnvironment;
+import org.apache.hop.core.exception.HopException;
+import org.apache.hop.core.exception.HopTransformException;
+import org.apache.hop.core.row.IRowMeta;
+import org.apache.hop.core.row.IValueMeta;
+import org.apache.hop.core.row.RowMeta;
+import org.apache.hop.core.variables.IVariables;
+import org.apache.hop.core.variables.Variables;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ParquetInputEnhancedMeta#getFields(IRowMeta, String, IRowMeta[],
+ * org.apache.hop.pipeline.transform.TransformMeta, IVariables,
+ * org.apache.hop.metadata.api.IHopMetadataProvider)}.
+ *
+ * <p>Tests cover: field list population with various types, optional file metadata fields, and
+ * variable resolution. The metadataFilename path (which reads an actual parquet file) is not tested
+ * here as it requires file I/O.
+ */
+class ParquetInputEnhancedMetaTest {
+
+  private ParquetInputEnhancedMeta meta;
+  private IVariables variables;
+
+  @BeforeAll
+  static void initHop() throws HopException {
+    HopEnvironment.init();
+  }
+
+  @BeforeEach
+  void setUp() {
+    meta = new ParquetInputEnhancedMeta();
+    variables = new Variables();
+  }
+
+  private IRowMeta callGetFields() throws HopTransformException {
+    IRowMeta rowMeta = new RowMeta();
+    meta.getFields(rowMeta, "testOrigin", null, null, variables, null);
+    return rowMeta;
+  }
+
+  // --- Field list population tests ---
+
+  @Test
+  void emptyFieldsListProducesNoOutputFields() throws HopTransformException {
+    // fields is empty, metadataFilename is null => nothing added
+    IRowMeta rowMeta = callGetFields();
+    assertEquals(0, rowMeta.size());
+  }
+
+  @Test
+  void singleStringField() throws HopTransformException {
+    meta.getFields().add(new ParquetField("src", "target_str", "String", null, null, null));
+
+    IRowMeta rowMeta = callGetFields();
+
+    assertEquals(1, rowMeta.size());
+    IValueMeta vm = rowMeta.getValueMeta(0);
+    assertEquals("target_str", vm.getName());
+    assertEquals(IValueMeta.TYPE_STRING, vm.getType());
+    assertEquals("testOrigin", vm.getOrigin());
+  }
+
+  @Test
+  void multipleFieldsWithVariousTypes() throws HopTransformException {
+    List<ParquetField> fields = new ArrayList<>();
+    fields.add(new ParquetField("s1", "col_string", "String", null, "100", null));
+    fields.add(new ParquetField("s2", "col_integer", "Integer", null, null, null));
+    fields.add(new ParquetField("s3", "col_number", "Number", "###.##", "10", "2"));
+    fields.add(new ParquetField("s4", "col_date", "Date", "yyyy-MM-dd", null, null));
+    fields.add(new ParquetField("s5", "col_boolean", "Boolean", null, null, null));
+    fields.add(new ParquetField("s6", "col_binary", "Binary", null, null, null));
+    fields.add(new ParquetField("s7", "col_bignumber", "BigNumber", null, null, null));
+    fields.add(new ParquetField("s8", "col_timestamp", "Timestamp", null, null, null));
+    meta.setFields(fields);
+
+    IRowMeta rowMeta = callGetFields();
+
+    assertEquals(8, rowMeta.size());
+
+    assertEquals("col_string", rowMeta.getValueMeta(0).getName());
+    assertEquals(IValueMeta.TYPE_STRING, rowMeta.getValueMeta(0).getType());
+    assertEquals(100, rowMeta.getValueMeta(0).getLength());
+
+    assertEquals("col_integer", rowMeta.getValueMeta(1).getName());
+    assertEquals(IValueMeta.TYPE_INTEGER, rowMeta.getValueMeta(1).getType());
+
+    assertEquals("col_number", rowMeta.getValueMeta(2).getName());
+    assertEquals(IValueMeta.TYPE_NUMBER, rowMeta.getValueMeta(2).getType());
+    assertEquals("###.##", rowMeta.getValueMeta(2).getConversionMask());
+    assertEquals(10, rowMeta.getValueMeta(2).getLength());
+    assertEquals(2, rowMeta.getValueMeta(2).getPrecision());
+
+    assertEquals("col_date", rowMeta.getValueMeta(3).getName());
+    assertEquals(IValueMeta.TYPE_DATE, rowMeta.getValueMeta(3).getType());
+
+    assertEquals("col_boolean", rowMeta.getValueMeta(4).getName());
+    assertEquals(IValueMeta.TYPE_BOOLEAN, rowMeta.getValueMeta(4).getType());
+
+    assertEquals("col_binary", rowMeta.getValueMeta(5).getName());
+    assertEquals(IValueMeta.TYPE_BINARY, rowMeta.getValueMeta(5).getType());
+
+    assertEquals("col_bignumber", rowMeta.getValueMeta(6).getName());
+    assertEquals(IValueMeta.TYPE_BIGNUMBER, rowMeta.getValueMeta(6).getType());
+
+    assertEquals("col_timestamp", rowMeta.getValueMeta(7).getName());
+    assertEquals(IValueMeta.TYPE_TIMESTAMP, rowMeta.getValueMeta(7).getType());
+  }
+
+  @Test
+  void allFieldsHaveCorrectOrigin() throws HopTransformException {
+    meta.getFields().add(new ParquetField("s1", "f1", "String", null, null, null));
+    meta.getFields().add(new ParquetField("s2", "f2", "Integer", null, null, null));
+
+    IRowMeta rowMeta = callGetFields();
+
+    for (int i = 0; i < rowMeta.size(); i++) {
+      assertEquals("testOrigin", rowMeta.getValueMeta(i).getOrigin());
+    }
+  }
+
+  // --- File field (fileField) tests ---
+
+  @Test
+  void fileFieldAddedWhenSet() throws HopTransformException {
+    meta.getFields().add(new ParquetField("s1", "f1", "String", null, null, null));
+    meta.setFileField("filename_col");
+
+    IRowMeta rowMeta = callGetFields();
+
+    assertEquals(2, rowMeta.size());
+    IValueMeta fileVm = rowMeta.getValueMeta(1);
+    assertEquals("filename_col", fileVm.getName());
+    assertEquals(IValueMeta.TYPE_STRING, fileVm.getType());
+    assertEquals(250, fileVm.getLength());
+    assertEquals("testOrigin", fileVm.getOrigin());
+  }
+
+  @Test
+  void fileFieldNotAddedWhenNull() throws HopTransformException {
+    meta.getFields().add(new ParquetField("s1", "f1", "String", null, null, null));
+    meta.setFileField(null);
+
+    IRowMeta rowMeta = callGetFields();
+    assertEquals(1, rowMeta.size());
+  }
+
+  @Test
+  void fileFieldNotAddedWhenEmpty() throws HopTransformException {
+    meta.getFields().add(new ParquetField("s1", "f1", "String", null, null, null));
+    meta.setFileField("");
+
+    IRowMeta rowMeta = callGetFields();
+    assertEquals(1, rowMeta.size());
+  }
+
+  // --- Additional metadata fields tests ---
+
+  @Test
+  void shortFileFieldAddedWhenSet() throws HopTransformException {
+    meta.setShortFileFieldName("short_file");
+
+    IRowMeta rowMeta = callGetFields();
+
+    assertEquals(1, rowMeta.size());
+    IValueMeta vm = rowMeta.getValueMeta(0);
+    assertEquals("short_file", vm.getName());
+    assertEquals(IValueMeta.TYPE_STRING, vm.getType());
+    assertEquals(100, vm.getLength());
+    assertEquals("testOrigin", vm.getOrigin());
+  }
+
+  @Test
+  void extensionFieldAddedWhenSet() throws HopTransformException {
+    meta.setExtensionFieldName("ext_field");
+
+    IRowMeta rowMeta = callGetFields();
+
+    assertEquals(1, rowMeta.size());
+    IValueMeta vm = rowMeta.getValueMeta(0);
+    assertEquals("ext_field", vm.getName());
+    assertEquals(IValueMeta.TYPE_STRING, vm.getType());
+    assertEquals(100, vm.getLength());
+  }
+
+  @Test
+  void pathFieldAddedWhenSet() throws HopTransformException {
+    meta.setPathFieldName("path_field");
+
+    IRowMeta rowMeta = callGetFields();
+
+    assertEquals(1, rowMeta.size());
+    IValueMeta vm = rowMeta.getValueMeta(0);
+    assertEquals("path_field", vm.getName());
+    assertEquals(IValueMeta.TYPE_STRING, vm.getType());
+    assertEquals(100, vm.getLength());
+  }
+
+  @Test
+  void sizeFieldAddedWhenSet() throws HopTransformException {
+    meta.setSizeFieldName("size_field");
+
+    IRowMeta rowMeta = callGetFields();
+
+    assertEquals(1, rowMeta.size());
+    IValueMeta vm = rowMeta.getValueMeta(0);
+    assertEquals("size_field", vm.getName());
+    assertEquals(IValueMeta.TYPE_INTEGER, vm.getType());
+    assertEquals(9, vm.getLength());
+  }
+
+  @Test
+  void hiddenFieldAddedWhenSet() throws HopTransformException {
+    meta.setHiddenFieldName("hidden_field");
+
+    IRowMeta rowMeta = callGetFields();
+
+    assertEquals(1, rowMeta.size());
+    IValueMeta vm = rowMeta.getValueMeta(0);
+    assertEquals("hidden_field", vm.getName());
+    assertEquals(IValueMeta.TYPE_BOOLEAN, vm.getType());
+  }
+
+  @Test
+  void lastModificationTimeFieldAddedWhenSet() throws HopTransformException {
+    meta.setLastModificationTimeFieldName("last_mod");
+
+    IRowMeta rowMeta = callGetFields();
+
+    assertEquals(1, rowMeta.size());
+    IValueMeta vm = rowMeta.getValueMeta(0);
+    assertEquals("last_mod", vm.getName());
+    assertEquals(IValueMeta.TYPE_DATE, vm.getType());
+  }
+
+  @Test
+  void uriFieldAddedWhenSet() throws HopTransformException {
+    meta.setUriNameFieldName("uri_field");
+
+    IRowMeta rowMeta = callGetFields();
+
+    assertEquals(1, rowMeta.size());
+    IValueMeta vm = rowMeta.getValueMeta(0);
+    assertEquals("uri_field", vm.getName());
+    assertEquals(IValueMeta.TYPE_STRING, vm.getType());
+    assertEquals(100, vm.getLength());
+  }
+
+  @Test
+  void rootUriFieldAddedWhenSet() throws HopTransformException {
+    meta.setRootUriNameFieldName("root_uri_field");
+
+    IRowMeta rowMeta = callGetFields();
+
+    assertEquals(1, rowMeta.size());
+    IValueMeta vm = rowMeta.getValueMeta(0);
+    assertEquals("root_uri_field", vm.getName());
+    assertEquals(IValueMeta.TYPE_STRING, vm.getType());
+    assertEquals(100, vm.getLength());
+  }
+
+  @Test
+  void noMetadataFieldsAddedWhenAllNamesAreNull() throws HopTransformException {
+    // All additional field names are null by default
+    IRowMeta rowMeta = callGetFields();
+    assertEquals(0, rowMeta.size());
+  }
+
+  @Test
+  void allMetadataFieldsAddedTogether() throws HopTransformException {
+    meta.getFields().add(new ParquetField("s1", "f1", "String", null, null, null));
+    meta.setFileField("file_col");
+    meta.setShortFileFieldName("short");
+    meta.setExtensionFieldName("ext");
+    meta.setPathFieldName("path");
+    meta.setSizeFieldName("size");
+    meta.setHiddenFieldName("hidden");
+    meta.setLastModificationTimeFieldName("lastmod");
+    meta.setUriNameFieldName("uri");
+    meta.setRootUriNameFieldName("rooturi");
+
+    IRowMeta rowMeta = callGetFields();
+
+    // 1 data field + fileField + 8 metadata fields = 10
+    assertEquals(10, rowMeta.size());
+
+    assertEquals("f1", rowMeta.getValueMeta(0).getName());
+    assertEquals("file_col", rowMeta.getValueMeta(1).getName());
+    assertEquals("short", rowMeta.getValueMeta(2).getName());
+    assertEquals("ext", rowMeta.getValueMeta(3).getName());
+    assertEquals("path", rowMeta.getValueMeta(4).getName());
+    assertEquals("size", rowMeta.getValueMeta(5).getName());
+    assertEquals("hidden", rowMeta.getValueMeta(6).getName());
+    assertEquals("lastmod", rowMeta.getValueMeta(7).getName());
+    assertEquals("uri", rowMeta.getValueMeta(8).getName());
+    assertEquals("rooturi", rowMeta.getValueMeta(9).getName());
+  }
+
+  // --- Variable resolution tests ---
+
+  @Test
+  void metadataFieldNamesResolveVariables() throws HopTransformException {
+    variables.setVariable("SHORT_NAME", "resolved_short");
+    variables.setVariable("EXT_NAME", "resolved_ext");
+
+    meta.setShortFileFieldName("${SHORT_NAME}");
+    meta.setExtensionFieldName("${EXT_NAME}");
+
+    IRowMeta rowMeta = callGetFields();
+
+    assertEquals(2, rowMeta.size());
+    assertEquals("resolved_short", rowMeta.getValueMeta(0).getName());
+    assertEquals("resolved_ext", rowMeta.getValueMeta(1).getName());
+  }
+
+  @Test
+  void fieldWithLengthAndPrecision() throws HopTransformException {
+    meta.getFields().add(new ParquetField("src", "num_field", "Number", "###.##", "15", "4"));
+
+    IRowMeta rowMeta = callGetFields();
+
+    assertEquals(1, rowMeta.size());
+    IValueMeta vm = rowMeta.getValueMeta(0);
+    assertEquals(15, vm.getLength());
+    assertEquals(4, vm.getPrecision());
+    assertEquals("###.##", vm.getConversionMask());
+  }
+}

--- a/transforms/parquet-enhanced/src/test/java/org/apache/hop/parquet/transforms/output/ParquetOutputEnhancedTest.java
+++ b/transforms/parquet-enhanced/src/test/java/org/apache/hop/parquet/transforms/output/ParquetOutputEnhancedTest.java
@@ -1,0 +1,384 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.parquet.transforms.output;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.text.DecimalFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import org.apache.hop.pipeline.transform.BaseTransform;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link ParquetOutputEnhanced#buildFilename(Object[], Date)}.
+ *
+ * <p>The buildFilename method is private, so we use reflection to invoke it. The method depends on:
+ * meta (flags controlling filename composition), data (split counter, beam context,
+ * filenameFieldIndex), and the transform itself (getCopyNr(), resolve()).
+ *
+ * <p>Because BaseTransform's constructor requires a fully initialized Pipeline (with variable
+ * support), we mock ParquetOutputEnhanced directly and set the required fields via reflection to
+ * avoid complex Pipeline/TransformMeta initialization.
+ */
+@ExtendWith(MockitoExtension.class)
+class ParquetOutputEnhancedTest {
+
+  private ParquetOutputEnhancedMeta meta;
+  private ParquetOutputEnhancedData data;
+  private ParquetOutputEnhanced transform;
+
+  private Method buildFilenameMethod;
+  private Date executionDate;
+
+  /**
+   * Creates a mock of ParquetOutputEnhanced with the given copyNr, and injects meta/data fields via
+   * reflection. We use a mock with CALLS_REAL_METHODS so that the private buildFilename() runs real
+   * code, while avoiding the BaseTransform constructor entirely.
+   */
+  private ParquetOutputEnhanced createTransformMock(int copyNr) throws Exception {
+    ParquetOutputEnhanced mockTransform = mock(ParquetOutputEnhanced.class, CALLS_REAL_METHODS);
+
+    // Inject meta into the BaseTransform.meta field
+    Field metaField = BaseTransform.class.getDeclaredField("meta");
+    metaField.setAccessible(true);
+    metaField.set(mockTransform, meta);
+
+    // Inject data into the BaseTransform.data field
+    Field dataField = BaseTransform.class.getDeclaredField("data");
+    dataField.setAccessible(true);
+    dataField.set(mockTransform, data);
+
+    // Set the copyNr
+    Field copyNrField = BaseTransform.class.getDeclaredField("copyNr");
+    copyNrField.setAccessible(true);
+    copyNrField.setInt(mockTransform, copyNr);
+
+    // Make resolve() return the input string (no variable substitution)
+    // Use lenient() because setUp always creates a mock, but some tests create a second one
+    lenient()
+        .doAnswer(invocation -> invocation.getArgument(0))
+        .when(mockTransform)
+        .resolve(anyString());
+    // Also handle resolve(null) which anyString() does not match
+    lenient().doReturn(null).when(mockTransform).resolve((String) isNull());
+
+    return mockTransform;
+  }
+
+  @BeforeEach
+  void setUp() throws Exception {
+    meta = new ParquetOutputEnhancedMeta();
+    data = new ParquetOutputEnhancedData();
+
+    transform = createTransformMock(0);
+
+    // Access the private buildFilename method
+    buildFilenameMethod =
+        ParquetOutputEnhanced.class.getDeclaredMethod("buildFilename", Object[].class, Date.class);
+    buildFilenameMethod.setAccessible(true);
+
+    // Use a fixed date for deterministic tests
+    executionDate = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2025-06-15 14:30:45");
+  }
+
+  private String invokeBuildFilename(Object[] row) throws Exception {
+    return (String) buildFilenameMethod.invoke(transform, row, executionDate);
+  }
+
+  @Test
+  void baseFilenameOnly() throws Exception {
+    meta.setFilenameBase("/tmp/output");
+    meta.setFilenameExtension("parquet");
+    meta.setFilenameIncludingCopyNr(false);
+    meta.setFilenameIncludingSplitNr(false);
+    meta.setCompressionCodec(CompressionCodecName.UNCOMPRESSED);
+
+    String result = invokeBuildFilename(null);
+
+    assertEquals("/tmp/output.parquet", result);
+  }
+
+  @Test
+  void filenameWithDateFlag() throws Exception {
+    meta.setFilenameBase("/tmp/output");
+    meta.setFilenameExtension("parquet");
+    meta.setFilenameIncludingDate(true);
+    meta.setFilenameIncludingCopyNr(false);
+    meta.setFilenameIncludingSplitNr(false);
+    meta.setCompressionCodec(CompressionCodecName.UNCOMPRESSED);
+
+    String result = invokeBuildFilename(null);
+
+    String expectedDate = new SimpleDateFormat("yyyyMMdd").format(executionDate);
+    assertEquals("/tmp/output-" + expectedDate + ".parquet", result);
+  }
+
+  @Test
+  void filenameWithTimeFlag() throws Exception {
+    meta.setFilenameBase("/tmp/output");
+    meta.setFilenameExtension("parquet");
+    meta.setFilenameIncludingTime(true);
+    meta.setFilenameIncludingCopyNr(false);
+    meta.setFilenameIncludingSplitNr(false);
+    meta.setCompressionCodec(CompressionCodecName.UNCOMPRESSED);
+
+    String result = invokeBuildFilename(null);
+
+    String expectedTime = new SimpleDateFormat("HHmmss").format(executionDate);
+    assertEquals("/tmp/output-" + expectedTime + ".parquet", result);
+  }
+
+  @Test
+  void filenameWithDateTimeFlag() throws Exception {
+    meta.setFilenameBase("/tmp/output");
+    meta.setFilenameExtension("parquet");
+    meta.setFilenameIncludingDateTime(true);
+    meta.setFilenameDateTimeFormat("yyyyMMdd-HHmmss");
+    meta.setFilenameIncludingCopyNr(false);
+    meta.setFilenameIncludingSplitNr(false);
+    meta.setCompressionCodec(CompressionCodecName.UNCOMPRESSED);
+
+    String result = invokeBuildFilename(null);
+
+    String expectedDateTime = new SimpleDateFormat("yyyyMMdd-HHmmss").format(executionDate);
+    assertEquals("/tmp/output-" + expectedDateTime + ".parquet", result);
+  }
+
+  @Test
+  void filenameWithCopyNr() throws Exception {
+    meta.setFilenameBase("/tmp/output");
+    meta.setFilenameExtension("parquet");
+    meta.setFilenameIncludingCopyNr(true);
+    meta.setFilenameIncludingSplitNr(false);
+    meta.setCompressionCodec(CompressionCodecName.UNCOMPRESSED);
+
+    // getCopyNr() returns 0 by default (set in createTransformMock)
+    String result = invokeBuildFilename(null);
+
+    assertEquals("/tmp/output-00.parquet", result);
+  }
+
+  @Test
+  void filenameWithCopyNrNonZero() throws Exception {
+    transform = createTransformMock(3);
+
+    meta.setFilenameBase("/tmp/output");
+    meta.setFilenameExtension("parquet");
+    meta.setFilenameIncludingCopyNr(true);
+    meta.setFilenameIncludingSplitNr(false);
+    meta.setCompressionCodec(CompressionCodecName.UNCOMPRESSED);
+
+    String result = invokeBuildFilename(null);
+
+    assertEquals("/tmp/output-03.parquet", result);
+  }
+
+  @Test
+  void filenameWithSplitNr() throws Exception {
+    meta.setFilenameBase("/tmp/output");
+    meta.setFilenameExtension("parquet");
+    meta.setFilenameIncludingCopyNr(false);
+    meta.setFilenameIncludingSplitNr(true);
+    meta.setCompressionCodec(CompressionCodecName.UNCOMPRESSED);
+
+    data.split = 5;
+
+    String result = invokeBuildFilename(null);
+
+    assertEquals("/tmp/output-0005.parquet", result);
+  }
+
+  @Test
+  void filenameWithBeamContext() throws Exception {
+    meta.setFilenameBase("/tmp/output");
+    meta.setFilenameExtension("parquet");
+    meta.setFilenameIncludingCopyNr(false);
+    meta.setFilenameIncludingSplitNr(false);
+    meta.setCompressionCodec(CompressionCodecName.UNCOMPRESSED);
+
+    data.setBeamContext(true);
+    data.setBeamBundleNr(42);
+
+    // Mock getLogChannelId
+    doReturn("log-channel-123").when(transform).getLogChannelId();
+
+    String result = invokeBuildFilename(null);
+
+    assertEquals("/tmp/output_log-channel-123_42.parquet", result);
+  }
+
+  @Test
+  void filenameFromFieldInRow() throws Exception {
+    meta.setFilenameInField(true);
+    meta.setFilenameExtension("parquet");
+    meta.setFilenameIncludingCopyNr(false);
+    meta.setFilenameIncludingSplitNr(false);
+    meta.setCompressionCodec(CompressionCodecName.UNCOMPRESSED);
+
+    data.filenameFieldIndex = 2;
+
+    Object[] row = new Object[] {"val1", "val2", "/data/dynamic_file", "val3"};
+
+    String result = invokeBuildFilename(row);
+
+    assertEquals("/data/dynamic_file.parquet", result);
+  }
+
+  @Test
+  void filenameFromFieldWithCopyNrAndSplitNr() throws Exception {
+    transform = createTransformMock(1);
+
+    meta.setFilenameInField(true);
+    meta.setFilenameExtension("parquet");
+    meta.setFilenameIncludingCopyNr(true);
+    meta.setFilenameIncludingSplitNr(true);
+    meta.setCompressionCodec(CompressionCodecName.UNCOMPRESSED);
+
+    data.filenameFieldIndex = 0;
+    data.split = 12;
+
+    Object[] row = new Object[] {"/data/output"};
+
+    String result = invokeBuildFilename(row);
+
+    assertEquals("/data/output-01-0012.parquet", result);
+  }
+
+  @Test
+  void filenameWithSnappyCompression() throws Exception {
+    meta.setFilenameBase("/tmp/output");
+    meta.setFilenameExtension("parquet");
+    meta.setFilenameIncludingCopyNr(false);
+    meta.setFilenameIncludingSplitNr(false);
+    meta.setCompressionCodec(CompressionCodecName.SNAPPY);
+
+    String result = invokeBuildFilename(null);
+
+    assertEquals("/tmp/output.parquet.snappy", result);
+  }
+
+  @Test
+  void filenameWithGzipCompression() throws Exception {
+    meta.setFilenameBase("/tmp/output");
+    meta.setFilenameExtension("parquet");
+    meta.setFilenameIncludingCopyNr(false);
+    meta.setFilenameIncludingSplitNr(false);
+    meta.setCompressionCodec(CompressionCodecName.GZIP);
+
+    String result = invokeBuildFilename(null);
+
+    assertEquals("/tmp/output.parquet.gz", result);
+  }
+
+  @Test
+  void filenameWithNullExtensionDefaultsToParquet() throws Exception {
+    meta.setFilenameBase("/tmp/output");
+    meta.setFilenameExtension(null);
+    meta.setFilenameIncludingCopyNr(false);
+    meta.setFilenameIncludingSplitNr(false);
+    meta.setCompressionCodec(CompressionCodecName.UNCOMPRESSED);
+
+    String result = invokeBuildFilename(null);
+
+    assertEquals("/tmp/output.parquet", result);
+  }
+
+  @Test
+  void filenameWithAllFlagsCombined() throws Exception {
+    meta.setFilenameBase("/tmp/output");
+    meta.setFilenameExtension("pq");
+    meta.setFilenameIncludingDate(true);
+    meta.setFilenameIncludingTime(true);
+    meta.setFilenameIncludingDateTime(true);
+    meta.setFilenameDateTimeFormat("yyyyMMdd-HHmmss");
+    meta.setFilenameIncludingCopyNr(true);
+    meta.setFilenameIncludingSplitNr(true);
+    meta.setCompressionCodec(CompressionCodecName.SNAPPY);
+
+    data.split = 7;
+
+    String result = invokeBuildFilename(null);
+
+    String expectedDate = new SimpleDateFormat("yyyyMMdd").format(executionDate);
+    String expectedTime = new SimpleDateFormat("HHmmss").format(executionDate);
+    String expectedDateTime = new SimpleDateFormat("yyyyMMdd-HHmmss").format(executionDate);
+
+    String expected =
+        "/tmp/output-"
+            + expectedDate
+            + "-"
+            + expectedTime
+            + "-"
+            + expectedDateTime
+            + "-"
+            + new DecimalFormat("00").format(0)
+            + "-"
+            + new DecimalFormat("0000").format(7)
+            + ".pq.snappy";
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void filenameFromFieldWithCompression() throws Exception {
+    meta.setFilenameInField(true);
+    meta.setFilenameExtension("parquet");
+    meta.setFilenameIncludingCopyNr(false);
+    meta.setFilenameIncludingSplitNr(false);
+    meta.setCompressionCodec(CompressionCodecName.GZIP);
+
+    data.filenameFieldIndex = 0;
+
+    Object[] row = new Object[] {"/data/compressed"};
+
+    String result = invokeBuildFilename(row);
+
+    assertEquals("/data/compressed.parquet.gz", result);
+  }
+
+  @Test
+  void filenameInFieldPathDoesNotIncludeDateOrTime() throws Exception {
+    // When filenameInField is true, date/time/datetime flags are ignored
+    meta.setFilenameInField(true);
+    meta.setFilenameExtension("parquet");
+    meta.setFilenameIncludingDate(true);
+    meta.setFilenameIncludingTime(true);
+    meta.setFilenameIncludingDateTime(true);
+    meta.setFilenameIncludingCopyNr(false);
+    meta.setFilenameIncludingSplitNr(false);
+    meta.setCompressionCodec(CompressionCodecName.UNCOMPRESSED);
+
+    data.filenameFieldIndex = 0;
+
+    Object[] row = new Object[] {"/data/field_file"};
+
+    String result = invokeBuildFilename(row);
+
+    // Date, time, and datetime flags should NOT affect the field-based path
+    assertEquals("/data/field_file.parquet", result);
+  }
+}


### PR DESCRIPTION
## Summary
- Add 16 unit tests for `ParquetOutputEnhanced.buildFilename()` covering: base filename, date/time/datetime flags, copyNr, splitNr, beam context, field-based filename, compression codec extensions, null extension default, and combined flags
- Add 19 unit tests for `ParquetInputEnhancedMeta.getFields()` covering: empty fields list, multiple field types (String, Integer, Number, Date, Boolean, Binary, BigNumber, Timestamp), fileField, all 8 optional metadata fields (shortFile, extension, path, size, hidden, lastModTime, uri, rootUri), variable resolution, and field length/precision

## Test plan
- [x] All 153 tests pass (`mvn test -s .m2/settings.xml -pl transforms/parquet-enhanced`)
- [x] Existing 118 tests unaffected
- [x] New tests have ASF 2.0 license headers

Fixes #14