### PR TITLE
Fix Cancel button marking pipeline as modified

### DIFF
--- a/transforms/parquet-enhanced/src/main/java/org/apache/hop/parquet/transforms/input/ParquetInputEnhancedDialog.java
+++ b/transforms/parquet-enhanced/src/main/java/org/apache/hop/parquet/transforms/input/ParquetInputEnhancedDialog.java
@@ -78,6 +78,7 @@ public class ParquetInputEnhancedDialog extends BaseTransformDialog implements I
       };
 
   protected ParquetInputEnhancedMeta input;
+  private boolean changed;
   private ModifyListener lsMod;
 
   private TableView wFields;
@@ -144,6 +145,7 @@ public class ParquetInputEnhancedDialog extends BaseTransformDialog implements I
     PropsUi.setLook(shell);
     setShellImage(shell, input);
     lsMod = e -> input.setChanged();
+    changed = input.hasChanged();
 
     FormLayout formLayout = new FormLayout();
     formLayout.marginWidth = PropsUi.getFormMargin();
@@ -299,6 +301,7 @@ public class ParquetInputEnhancedDialog extends BaseTransformDialog implements I
                 true));
 
     getData(input);
+    input.setChanged(changed);
 
     wTabFolder.setSelection(0);
 
@@ -1254,6 +1257,7 @@ public class ParquetInputEnhancedDialog extends BaseTransformDialog implements I
 
   private void cancel() {
     returnValue = null;
+    input.setChanged(changed);
     dispose();
   }
 }


### PR DESCRIPTION
## Summary
- Save the original `changed` state of `ParquetInputEnhancedMeta` before widget listeners can trigger modifications
- Restore the `changed` state after `getData()` populates widgets (which fires `lsMod` listeners)
- Restore the `changed` state in `cancel()` so dismissing the dialog does not leave the pipeline dirty

Fixes #25

## Test plan
- Open a pipeline containing a ParquetInputEnhanced transform
- Open the transform dialog, then click Cancel
- Verify the pipeline is NOT marked as modified (no asterisk in the title)
- Open the dialog again, make a real change, click OK, then verify the pipeline IS marked as modified