### PR TITLE
Bump GitHub Actions to Node.js 24 compatible majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -28,7 +28,7 @@ jobs:
 
       - name: Upload snapshot artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: snapshot-${{ github.sha }}
           path: assemblies/assemblies-parquet-enhanced/target/hop-parquet-plugin-*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate SemVer tag
         run: |
@@ -22,7 +22,7 @@ jobs:
           fi
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -69,7 +69,7 @@ jobs:
             > "hop-parquet-plugin-${{ steps.version.outputs.VERSION }}.zip.sha256"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             assemblies/assemblies-parquet-enhanced/target/hop-parquet-plugin-${{ steps.version.outputs.VERSION }}.zip


### PR DESCRIPTION
## Summary

Risolve la deprecazione segnalata da GitHub durante l'esecuzione del workflow `Release` per `v1.0.0-beta.1`: tutte le action a Node.js 20 sono state aggiornate ai major più recenti compatibili con Node.js 24.

| Action | Da | A |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-java` | v4 | v5 |
| `actions/upload-artifact` | v4 | v7 |
| `softprops/action-gh-release` | v2 | v3 |

## Test plan

- [ ] Il workflow `CI` gira verde su questa PR (validando `checkout@v6`, `setup-java@v5`, `upload-artifact@v7`).
- [ ] Dopo merge: la prossima release validerà anche `softprops/action-gh-release@v3`.

Fixes #36