### PR TITLE
fix: release VFS resources in extractRowMeta (Get fields lock)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Under `[Unreleased]`, every pull request that introduces a user-visible change a
 
 ## [Unreleased]
 
+### Fixed
+
+- Parquet input file remained locked after using "Get fields" in the dialog: `ParquetInputEnhancedMeta.extractRowMeta` now closes the VFS `FileObject`, the input stream and the `ParquetReader` deterministically via try-with-resources (#22).
+
 ## [1.0.0-beta.1] - 2026-05-01
 
 ### Added

--- a/transforms/parquet-enhanced/src/main/java/org/apache/hop/parquet/transforms/input/ParquetInputEnhancedMeta.java
+++ b/transforms/parquet-enhanced/src/main/java/org/apache/hop/parquet/transforms/input/ParquetInputEnhancedMeta.java
@@ -274,30 +274,28 @@ public class ParquetInputEnhancedMeta
   }
 
   public static IRowMeta extractRowMeta(IVariables variables, String filename) throws HopException {
-    try {
-      FileObject fileObject = HopVfs.getFileObject(variables.resolve(filename), variables);
-
+    try (FileObject fileObject = HopVfs.getFileObject(variables.resolve(filename), variables)) {
+      byte[] bytes;
       long size = fileObject.getContent().getSize();
-      InputStream inputStream = HopVfs.getInputStream(fileObject);
-
-      // Reads the whole file into memory...
-      //
-      ByteArrayOutputStream outputStream = new ByteArrayOutputStream((int) size);
-      IOUtils.copy(inputStream, outputStream);
-      ParquetStream inputFile = new ParquetStream(outputStream.toByteArray(), filename);
+      try (InputStream inputStream = HopVfs.getInputStream(fileObject);
+          ByteArrayOutputStream outputStream = new ByteArrayOutputStream((int) size)) {
+        IOUtils.copy(inputStream, outputStream);
+        bytes = outputStream.toByteArray();
+      }
+      ParquetStream inputFile = new ParquetStream(bytes, filename);
       // Empty list of fields to retrieve: we still grab the schema
       //
       ParquetReadSupport readSupport = new ParquetReadSupport(new ArrayList<>());
-      ParquetReader<RowMetaAndData> reader =
-          new ParquetReaderBuilder<>(readSupport, inputFile).build();
-
-      // Read one empty row...
-      //
-      reader.read();
-
-      // Now we have the schema...
-      //
-      MessageType schema = readSupport.getMessageType();
+      MessageType schema;
+      try (ParquetReader<RowMetaAndData> reader =
+          new ParquetReaderBuilder<>(readSupport, inputFile).build()) {
+        // Read one empty row...
+        //
+        reader.read();
+        // Now we have the schema...
+        //
+        schema = readSupport.getMessageType();
+      }
       IRowMeta rowMeta = new RowMeta();
       List<ColumnDescriptor> columns = schema.getColumns();
       for (ColumnDescriptor column : columns) {


### PR DESCRIPTION
## Summary

- The "Get fields" button in `ParquetInputEnhancedDialog` calls `ParquetInputEnhancedMeta.extractRowMeta`, which opened a VFS `FileObject`, an `InputStream` and a `ParquetReader` and never closed them. The `FileObject` held an OS-level lock on the Parquet file until Hop was shut down, preventing rename/delete after the dialog action.
- Wrapped `FileObject`, `InputStream`/`ByteArrayOutputStream` and `ParquetReader` in `try-with-resources` so all resources are released deterministically, including on the exception path. No behavioural change to schema extraction.
- This is the dialog-side counterpart of the runtime fix already shipped in `ParquetInputEnhanced.getRowsFromParquetFile`, addressing the regression reported in #22 by @liosc.

## Test plan

- [x] `mvn clean verify -s .m2/settings.xml` passes locally
- [ ] Manual: open the input dialog, pick a Parquet file, click "Get fields", close the dialog, verify the file can be renamed/deleted on the OS without restarting Hop
- [ ] Manual: same flow under Windows (original locking environment)

Fixes #22